### PR TITLE
modified for dynamic batch size in sample

### DIFF
--- a/soundstorm/s2/engine/solver.py
+++ b/soundstorm/s2/engine/solver.py
@@ -249,7 +249,7 @@ class Solver(object):
             # only save the wav of first 5 in batch
             # target wav in batch is reverse sorted with length
             audio_indexs = []
-            for i in range(10):
+            for i in range(content_gt.size(0)):
                 save_name_gt_wav = save_path + '/gt_' + str(i) + '.wav'
                 acoustic_token_gt = codes_np_gt[i]
                 # all Nq have same pad length
@@ -300,7 +300,7 @@ class Solver(object):
             # self.hificodec
             np.save(save_name, codes_np)
             if gen_audio:
-                for i in range(10):
+                for i in range(codes.size(0)):
                     save_name_wav = save_path + name_prefix + '_' + str(
                         i) + '.wav'
                     acoustic_token = codes_np[i]


### PR DESCRIPTION
when config to small batchsize, sample funcion in solver.py will out of scope, such as:
    acoustic_token_gt = codes_np_gt[i]
IndexError: index 7 is out of bounds for axis 0 with size 7
so change to dynamic batchsize to avoid such problem.
